### PR TITLE
Use AsyncStorage from react-native-community

### DIFF
--- a/RatingsData.js
+++ b/RatingsData.js
@@ -1,4 +1,5 @@
-import React, { AsyncStorage } from 'react-native';
+import React from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 const keyPrefix = '@RatingRequestData.';
 const eventCountKey = keyPrefix + 'positiveEventCount';

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/jlyman/react-native-rating-requestor#readme",
   "peerDependencies": {
-    "react-native": ">= 0.26.0"
+    "react-native": ">= 0.26.0",
+    "@react-native-community/async-storage": "^1.4.2"
   }
 }


### PR DESCRIPTION
AsyncStorage from native is deprecated so we will get this message:
```
  ● Console

    console.error node_modules/react-native/node_modules/fbjs/lib/warning.js:30
      Warning: Async Storage has been extracted from react-native core and will be removed in a future release. It can now be installed and imported from '@react-native-community/async-storage' instead of 'react-native'. See https://github.com/react-native-community/react-native-async-storage
```

We we need to use AsyncStorage from '@react-native-community/async-storage' instead (https://github.com/react-native-community/react-native-async-storage)

This change is part of what's needed to update our usage of AsyncStorage in killi-app since we are using this library and the error is coming from here. If this works out well for us, we can also do the same PR on the original library (https://github.com/jlyman/react-native-rating-requestor) 